### PR TITLE
Add mod.json file to repository root

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -1,0 +1,47 @@
+// Lines starting with // are comments and ignored
+// Feel free to delete these comments after use
+{
+    // Required
+    // Human-readable names with casing, punctuation, etc. are encouraged
+    "name": "Aurora Community Balance Patch",
+
+    // Optional (but highly encouraged)
+    "description": "A collaborative DB mod primarily containing tweaks to techs and & part stats.",
+
+    // Required
+    // Approved, Public, or Poweruser
+    // Casing does not matter
+    "status": "poweruser",
+
+    // Required
+    // Executable, Database, RootUtility, or Utility
+    // Casing does not matter
+    "type": "database",
+
+    // Optional
+    // The command used to configure the mod
+    // Generally just the filename of a readme or config file
+    "configuration_file": "techs.sql",
+
+    // Optional
+    // Not yet implemented
+    "changelog_file": "",
+
+    // Optional
+    // Point to your mod's repository, forum, AAR, etc
+    "url": "https://github.com/Aurora-Modders/AuroraCBP",
+
+    "downloads":
+    [
+        {
+            "version": "1.8.0-0.5",
+            "target_aurora_version": "1.8",
+            "download_url": "https://raw.githubusercontent.com/Aurora-Modders/AuroraCBP/master/Aurora%20CBP/Releases/AuroraCBP-1.8.0-0.5.zip"
+        },
+        {
+            "version": "1.8.0-0.6",
+            "target_aurora_version": "1.9",
+            "download_url": "https://raw.githubusercontent.com/Aurora-Modders/AuroraCBP/master/Aurora%20CBP/Releases/AuroraCBP-1.8.0-0.5.zip"
+        }
+    ]
+}


### PR DESCRIPTION
This file doesn't need to be included in the .zip file or anything. https://github.com/Aurora-Modders/AuroraRegistry/pull/8 will point the registry at this new file. AuroraLoader will be moving away from the old `mod.ini` format fairly soon and the new `mod.json` should enable you to manage your mod's releases without leaving the repo. 

Threw in a quick hack to indicate that Aurora CBP is compatible with 1.9.* as well.